### PR TITLE
feat(table): implement edit record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.4-alpha.3] - 2025-07-06
+
+### Added
+
+- **Record Editing Feature**
+  - Added ability to edit records directly from the table interface
+  - Implemented edit buttons in both table rows and record detail modal
+  - Added AJAX-based form loading and submission for record editing
+  - Added toast notifications for edit success/failure
+  - Added `enable_record_editing` configuration option (enabled by default)
+  - Integrated field-specific inputs with Select2 and Flatpickr for improved UX
+
 ## [0.9.4-alpha.2] - 2025-07-06
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dbviewer (0.9.4.pre.alpha.2)
+    dbviewer (0.9.4.pre.alpha.3)
       activerecord (>= 7.0.0)
       csv
       propshaft (>= 1.1.0)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It's designed for development, debugging, and database analysis, offering a clea
 - **Detailed Schema Information** - Column details, indexes, and constraints
 - **Entity Relationship Diagram (ERD)** - Interactive database schema visualization
 - **Data Browsing** - Paginated record viewing with search and filtering
-- **Data Management** - Create and delete database records directly from the interface
+- **Data Management** - Full CRUD operations (Create, Read, Update, Delete) for database records
 - **SQL Queries** - Safe SQL query execution with validation
 - **Multiple Database Connections** - Support for multiple database sources
 - **PII Data Masking** - Configurable masking for sensitive data
@@ -80,6 +80,27 @@ This is necessary because API-only Rails applications don't include the Flash mi
 - **ERD View** (`/dbviewer/entity_relationship_diagrams`): Interactive Entity Relationship Diagram of your database
 - **SQL Query Logs** (`/dbviewer/logs`): View and analyze logged SQL queries with performance metrics
 
+### Data Management Features
+
+DBViewer provides a complete set of CRUD (Create, Read, Update, Delete) operations for your database records:
+
+- **Create**: Add new records via a user-friendly modal form with field validation
+- **Read**: Browse and view detailed record information with relationship navigation
+- **Update**: Edit existing records through an intuitive form interface
+- **Delete**: Remove records with confirmation dialogs to prevent accidental deletion
+
+All data management features can be individually enabled or disabled through configuration options:
+
+```ruby
+# config/initializers/dbviewer.rb
+Dbviewer.configure do |config|
+  # Data management options
+  config.enable_data_export = false    # Enable CSV export feature
+  config.enable_record_deletion = true # Enable record deletion feature
+  config.enable_record_editing = true  # Enable record editing feature
+end
+```
+
 ## ⚙️ Configuration Options
 
 You can configure DBViewer by using our generator to create an initializer in your application:
@@ -100,6 +121,7 @@ Dbviewer.configure do |config|
   config.max_records = 10000                         # Maximum records to return in any query
   config.enable_data_export = false                  # Whether to allow data exporting
   config.enable_record_deletion = true               # Whether to allow record deletion
+  config.enable_record_editing = true                # Whether to allow record editing
   config.query_timeout = 30                          # SQL query timeout in seconds
 
   # Query logging options

--- a/app/assets/javascripts/dbviewer/record_editing.js
+++ b/app/assets/javascripts/dbviewer/record_editing.js
@@ -7,7 +7,10 @@ document.addEventListener("DOMContentLoaded", function () {
   if (recordDetailEditBtn) {
     recordDetailEditBtn.addEventListener("click", () => {
       const recordData = extractRecordDataFromDetailModal();
-      const primaryKeyValue = extractPrimaryKeyValue(recordData);
+      // Use the primary key from the button's data attribute
+      const primaryKey =
+        recordDetailEditBtn.getAttribute("data-primary-key") || "id";
+      const primaryKeyValue = recordData[primaryKey];
       loadEditForm(primaryKeyValue);
     });
   }
@@ -41,6 +44,24 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   function extractPrimaryKeyValue(recordData) {
+    // First try to get the primary key from the button data attribute
+    const clickedButton = document.activeElement;
+    if (
+      clickedButton &&
+      clickedButton.classList.contains("edit-record-btn") &&
+      clickedButton.dataset.primaryKey
+    ) {
+      const primaryKey = clickedButton.dataset.primaryKey;
+      return recordData[primaryKey];
+    }
+
+    // If not available, use the table-level metadata primary key from the hidden field
+    const primaryKeyMetaElement = document.getElementById("table_primary_key");
+    if (primaryKeyMetaElement && primaryKeyMetaElement.value) {
+      return recordData[primaryKeyMetaElement.value];
+    }
+
+    // Fallback: try to find 'id' or use the first key
     const primaryKey =
       Object.keys(recordData).find((key) => key.toLowerCase() === "id") ||
       Object.keys(recordData)[0];

--- a/app/assets/javascripts/dbviewer/record_editing.js
+++ b/app/assets/javascripts/dbviewer/record_editing.js
@@ -1,0 +1,187 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const tableName = document.getElementById("table_name")?.value;
+  if (!tableName) return;
+
+  // Handle edit button in record detail modal
+  const recordDetailEditBtn = document.getElementById("recordDetailEditBtn");
+  if (recordDetailEditBtn) {
+    recordDetailEditBtn.addEventListener("click", () => {
+      const recordData = extractRecordDataFromDetailModal();
+      const primaryKeyValue = extractPrimaryKeyValue(recordData);
+      loadEditForm(primaryKeyValue);
+    });
+  }
+
+  // Handle edit buttons in table rows
+  document.querySelectorAll(".edit-record-btn").forEach((button) => {
+    button.addEventListener("click", () => {
+      const recordData = JSON.parse(button.dataset.recordData || "{}");
+      const primaryKeyValue = extractPrimaryKeyValue(recordData);
+      loadEditForm(primaryKeyValue);
+    });
+  });
+
+  function extractRecordDataFromDetailModal() {
+    const tableBody = document.getElementById("recordDetailTableBody");
+    const rows = tableBody?.querySelectorAll("tr") || [];
+    const recordData = {};
+
+    rows.forEach((row) => {
+      const cells = row.querySelectorAll("td");
+      if (cells.length >= 2) {
+        const columnName = cells[0].textContent.trim();
+        const cellValue =
+          cells[1].textContent.trim() === "NULL"
+            ? ""
+            : cells[1].textContent.trim();
+        recordData[columnName] = cellValue;
+      }
+    });
+    return recordData;
+  }
+
+  function extractPrimaryKeyValue(recordData) {
+    const primaryKey =
+      Object.keys(recordData).find((key) => key.toLowerCase() === "id") ||
+      Object.keys(recordData)[0];
+    return recordData[primaryKey];
+  }
+
+  async function loadEditForm(recordId) {
+    const modal = document.getElementById("editRecordModal");
+    const modalBody = modal.querySelector(".modal-content");
+    const bsModal = new bootstrap.Modal(modal);
+
+    modalBody.innerHTML = `
+      <div class="modal-body text-center py-5">
+        <div class="spinner-border text-primary" role="status"></div>
+        <p class="mt-3">Loading edit form...</p>
+      </div>
+    `;
+
+    bsModal.show();
+
+    try {
+      const response = await fetch(
+        `${window.location.pathname}/records/${encodeURIComponent(
+          recordId
+        )}/edit`
+      );
+      if (!response.ok) throw new Error("Failed to load form");
+
+      const html = await response.text();
+      modalBody.innerHTML = html;
+
+      initializeEditFormElements();
+      document
+        .getElementById("editRecordForm")
+        ?.addEventListener("submit", handleEditFormSubmit);
+    } catch (error) {
+      modalBody.innerHTML = `
+        <div class="modal-header">
+          <h5 class="modal-title">Error</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <div class="alert alert-danger">${error.message}</div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        </div>
+      `;
+    }
+  }
+
+  function initializeEditFormElements() {
+    if (typeof $.fn.select2 !== "undefined") {
+      $(".select2-dropdown").select2({
+        dropdownParent: $("#editRecordModal"),
+        theme: "bootstrap-5",
+        width: "100%",
+      });
+    }
+
+    if (typeof flatpickr !== "undefined") {
+      flatpickr(".datetime-picker", {
+        enableTime: true,
+        dateFormat: "Y-m-d H:i:S",
+        time_24hr: true,
+        wrap: true,
+      });
+
+      flatpickr(".date-picker", {
+        dateFormat: "Y-m-d",
+        wrap: true,
+      });
+    }
+  }
+
+  async function handleEditFormSubmit(event) {
+    event.preventDefault();
+
+    const form = event.target;
+    const submitButton = document.getElementById("updateRecordButton");
+    const originalText = submitButton?.innerHTML;
+    const formData = new FormData(form);
+    const csrfToken = document.querySelector(
+      'meta[name="csrf-token"]'
+    )?.content;
+
+    disableSubmitButton(submitButton, "Updating...");
+
+    try {
+      const response = await fetch(form.action, {
+        method: form.method,
+        body: formData,
+        headers: { "X-CSRF-Token": csrfToken },
+        credentials: "same-origin",
+      });
+
+      const result = await response.json();
+
+      if (!response.ok)
+        throw new Error(
+          result?.messages?.join(", ") || "Failed to update record"
+        );
+
+      bootstrap.Modal.getInstance(
+        document.getElementById("editRecordModal")
+      )?.hide();
+      showToast(result.message || "Record updated successfully");
+      setTimeout(() => window.location.reload(), 1000);
+    } catch (error) {
+      showToast(error.message, "danger");
+    } finally {
+      enableSubmitButton(submitButton, originalText);
+    }
+  }
+
+  function disableSubmitButton(button, loadingText) {
+    if (!button) return;
+    button.disabled = true;
+    button.innerHTML = `<span class="spinner-border spinner-border-sm me-2"></span>${loadingText}`;
+  }
+
+  function enableSubmitButton(button, originalText) {
+    if (!button) return;
+    button.disabled = false;
+    button.innerHTML = originalText;
+  }
+
+  function showToast(message, type = "success") {
+    Toastify({
+      text: `<span class="toast-icon"><i class="bi bi-${
+        type === "success" ? "clipboard-check" : "exclamation-triangle"
+      }"></i></span> ${message}`,
+      className: "toast-factory-bot",
+      duration: 3000,
+      gravity: "bottom",
+      position: "right",
+      escapeMarkup: false,
+      style: {
+        animation: `slideInRight 0.3s ease-out, slideOutRight 0.3s ease-out 2.7s`,
+        background: type === "danger" ? "#dc3545" : undefined,
+      },
+    }).showToast();
+  }
+});

--- a/app/helpers/dbviewer/datatable_ui_table_helper.rb
+++ b/app/helpers/dbviewer/datatable_ui_table_helper.rb
@@ -145,7 +145,8 @@ module Dbviewer
               title: "Edit Record",
               data: {
                 record_data: data_attributes.to_json,
-                table_name: table_name
+                table_name: table_name,
+                primary_key: metadata && metadata[:primary_key] ? metadata[:primary_key] : "id"
               }
             ) do
               content_tag(:i, "", class: "bi bi-pencil")

--- a/app/helpers/dbviewer/datatable_ui_table_helper.rb
+++ b/app/helpers/dbviewer/datatable_ui_table_helper.rb
@@ -137,6 +137,23 @@ module Dbviewer
             content_tag(:i, "", class: "bi bi-clipboard")
           end
 
+          # Edit Record button (only if enabled in configuration)
+          edit_button = if Dbviewer.configuration.enable_record_editing
+            button_tag(
+              type: "button",
+              class: "btn btn-sm btn-outline-primary edit-record-btn",
+              title: "Edit Record",
+              data: {
+                record_data: data_attributes.to_json,
+                table_name: table_name
+              }
+            ) do
+              content_tag(:i, "", class: "bi bi-pencil")
+            end
+          else
+            "".html_safe
+          end
+
           # Delete Record button (only if enabled in configuration)
           delete_button = if Dbviewer.configuration.enable_record_deletion
             button_tag(
@@ -157,7 +174,7 @@ module Dbviewer
           end
 
           # Concatenate all buttons
-          view_button + copy_factory_button + delete_button
+          view_button + copy_factory_button + edit_button + delete_button
         end
       end
     end

--- a/app/views/dbviewer/tables/_record_form_fields.html.erb
+++ b/app/views/dbviewer/tables/_record_form_fields.html.erb
@@ -1,0 +1,105 @@
+<%
+  # Common variables:
+  # - form: The form builder
+  # - column: Current column hash with :name, :type, etc.
+  # - metadata: Table metadata with :foreign_keys etc.
+  # - foreign_key_options: Options for foreign key dropdowns
+  # - record: The record being edited (nil for new records)
+  # - is_edit_mode: Boolean flag indicating if this is an edit (vs create) operation
+  
+  column_name = column[:name]
+  is_primary_key = metadata[:primary_key] == column_name
+  
+  # For new records, skip auto-increment primary keys
+  skip_column = !is_edit_mode && is_primary_key && %w[id].include?(column_name.downcase)
+  
+  # Skip timestamps for both new and edit
+  return if skip_column || %w[created_at updated_at].include?(column_name)
+  
+  # Get current value for edit mode
+  current_value = record ? record[column_name] : nil
+  
+  # Common field properties
+  field_type = determine_field_type(column[:type])
+  foreign_key = metadata[:foreign_keys].find { |fk| fk[:column] == column_name }
+  field_id = "record_#{column_name}"
+  required = !column[:null]
+  disabled = is_edit_mode && is_primary_key # Disable editing of primary key in edit mode
+%>
+
+<div class="mb-3">
+  <%= form.label "record[#{column_name}]", column_name.humanize, class: "form-label" %>
+  
+  <% if foreign_key && foreign_key_options[column_name].present? %>
+    <!-- Foreign key dropdown -->
+    <%= form.select "record[#{column_name}]", 
+                options_for_select(foreign_key_options[column_name], current_value),
+                { include_blank: column[:null] ? "-- Select --" : false }, 
+                { class: "form-control select2-dropdown", id: field_id, disabled: disabled } %>
+                
+  <% elsif field_type == :text || field_type == :text_area %>
+    <!-- Text area for long text fields -->
+    <%= form.text_area "record[#{column_name}]", 
+                    value: current_value, 
+                    class: "form-control", 
+                    id: field_id, 
+                    rows: 3, 
+                    required: required, 
+                    disabled: disabled %>
+    
+  <% elsif field_type == :boolean || field_type == :check_box %>
+    <!-- Boolean field -->
+    <div class="form-check form-switch">
+      <%= form.check_box "record[#{column_name}]", 
+                      { class: "form-check-input", 
+                        id: field_id, 
+                        checked: current_value, 
+                        disabled: disabled }, 
+                      "true", "false" %>
+    </div>
+    
+  <% elsif field_type == :datetime %>
+    <!-- Date time picker -->
+    <div class="input-group flatpickr">
+      <%= form.text_field "record[#{column_name}]", 
+                      value: current_value, 
+                      class: "form-control datetime-picker", 
+                      id: field_id, 
+                      required: required, 
+                      data: { input: "" }, 
+                      disabled: disabled %>
+      <button type="button" class="input-group-text" data-toggle><i class="bi bi-calendar-event"></i></button>
+    </div>
+    
+  <% elsif field_type == :date %>
+    <!-- Date picker -->
+    <div class="input-group flatpickr">
+      <%= form.text_field "record[#{column_name}]", 
+                      value: current_value, 
+                      class: "form-control date-picker", 
+                      id: field_id, 
+                      required: required, 
+                      data: { input: "" }, 
+                      disabled: disabled %>
+      <button type="button" class="input-group-text" data-toggle><i class="bi bi-calendar-event"></i></button>
+    </div>
+    
+  <% else %>
+    <!-- Default text input -->
+    <%= form.text_field "record[#{column_name}]", 
+                    value: current_value, 
+                    class: "form-control", 
+                    id: field_id, 
+                    required: required, 
+                    disabled: disabled %>
+  <% end %>
+  
+  <% if disabled %>
+    <!-- Add a hidden field to preserve the primary key value -->
+    <%= form.hidden_field "record[#{column_name}]", value: current_value %>
+  <% end %>
+  
+  <% if !is_edit_mode && column[:default].present? && column[:default] != "NULL" %>
+    <div class="form-text text-muted">Default: <%= column[:default] %></div>
+  <% end %>
+</div>

--- a/app/views/dbviewer/tables/_record_form_fields.html.erb
+++ b/app/views/dbviewer/tables/_record_form_fields.html.erb
@@ -11,7 +11,7 @@
   is_primary_key = metadata[:primary_key] == column_name
   
   # For new records, skip auto-increment primary keys
-  skip_column = !is_edit_mode && is_primary_key && %w[id].include?(column_name.downcase)
+  skip_column = !is_edit_mode && is_primary_key # Skip primary key in creation mode
   
   # Skip timestamps for both new and edit
   return if skip_column || %w[created_at updated_at].include?(column_name)

--- a/app/views/dbviewer/tables/edit_record.html.erb
+++ b/app/views/dbviewer/tables/edit_record.html.erb
@@ -21,70 +21,15 @@
 
   <%= form_with url: update_record_table_path(@table_name, record_id: primary_key_value), method: :patch, id: "editRecordForm" do |form| %>
     <% @table_columns.each do |column| %>
-      <% 
-        column_name = column[:name]
-        is_primary_key = primary_key == column_name
-        
-        # Skip timestamps
-        next if %w[created_at updated_at].include?(column_name)
-
-        # Get current value
-        current_value = @record[column_name]
-      %>
-      
-      <div class="mb-3">
-        <% 
-          # Handle different field types
-          field_type = determine_field_type(column[:type])
-          foreign_key = @metadata[:foreign_keys].find { |fk| fk[:column] == column_name }
-          field_id = "record_#{column_name}"
-          required = !column[:null]
-          disabled = is_primary_key # Disable editing of primary key
-        %>
-        
-        <%= form.label "record[#{column_name}]", column_name.humanize, class: "form-label" %>
-        
-        <% if foreign_key && @foreign_key_options[column_name].present? %>
-          <!-- Foreign key dropdown -->
-          <%= form.select "record[#{column_name}]", 
-                      options_for_select(@foreign_key_options[column_name], current_value),
-                      {  }, 
-                      { class: "form-control select2-dropdown", id: field_id, required: required, disabled: disabled } %>
-                      
-        <% elsif field_type == :text %>
-          <!-- Text area for long text fields -->
-          <%= form.text_area "record[#{column_name}]", value: current_value, class: "form-control", id: field_id, rows: 3, required: required, disabled: disabled %>
-          
-        <% elsif field_type == :boolean %>
-          <!-- Boolean field -->
-          <div class="form-check form-switch">
-            <%= form.check_box "record[#{column_name}]", { class: "form-check-input", id: field_id, checked: current_value, disabled: disabled }, "true", "false" %>
-          </div>
-          
-        <% elsif field_type == :datetime %>
-          <!-- Date time picker -->
-          <div class="input-group flatpickr">
-            <%= form.text_field "record[#{column_name}]", value: current_value, class: "form-control datetime-picker", id: field_id, required: required, data: { input: "" }, disabled: disabled %>
-            <button type="button" class="input-group-text" data-toggle><i class="bi bi-calendar-event"></i></button>
-          </div>
-          
-        <% elsif field_type == :date %>
-          <!-- Date picker -->
-          <div class="input-group flatpickr">
-            <%= form.text_field "record[#{column_name}]", value: current_value, class: "form-control date-picker", id: field_id, required: required, data: { input: "" }, disabled: disabled %>
-            <button type="button" class="input-group-text" data-toggle><i class="bi bi-calendar-event"></i></button>
-          </div>
-          
-        <% else %>
-          <!-- Default text input -->
-          <%= form.text_field "record[#{column_name}]", value: current_value, class: "form-control", id: field_id, required: required, disabled: disabled %>
-        <% end %>
-        
-        <% if disabled %>
-          <!-- Add a hidden field to preserve the primary key value -->
-          <%= form.hidden_field "record[#{column_name}]", value: current_value %>
-        <% end %>
-      </div>
+      <%= render partial: 'dbviewer/tables/record_form_fields', 
+                 locals: { 
+                   form: form, 
+                   column: column, 
+                   metadata: @metadata, 
+                   foreign_key_options: @foreign_key_options, 
+                   record: @record, 
+                   is_edit_mode: true 
+                 } %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/dbviewer/tables/edit_record.html.erb
+++ b/app/views/dbviewer/tables/edit_record.html.erb
@@ -1,0 +1,97 @@
+<% if @errors.present? %>
+  <div class="alert alert-danger">
+    <ul class="mb-0">
+      <% @errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<div class="modal-header">
+  <h5 class="modal-title" id="editRecordModalLabel">
+    <i class="bi bi-pencil-square me-1"></i> Edit <%= @table_name.humanize.titleize %> Record
+  </h5>
+  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+</div>
+
+<div class="modal-body">
+  <% primary_key = @metadata[:primary_key] || "id" %>
+  <% primary_key_value = @record[primary_key] %>
+
+  <%= form_with url: update_record_table_path(@table_name, record_id: primary_key_value), method: :patch, id: "editRecordForm" do |form| %>
+    <% @table_columns.each do |column| %>
+      <% 
+        column_name = column[:name]
+        is_primary_key = primary_key == column_name
+        
+        # Skip timestamps
+        next if %w[created_at updated_at].include?(column_name)
+
+        # Get current value
+        current_value = @record[column_name]
+      %>
+      
+      <div class="mb-3">
+        <% 
+          # Handle different field types
+          field_type = determine_field_type(column[:type])
+          foreign_key = @metadata[:foreign_keys].find { |fk| fk[:column] == column_name }
+          field_id = "record_#{column_name}"
+          required = !column[:null]
+          disabled = is_primary_key # Disable editing of primary key
+        %>
+        
+        <%= form.label "record[#{column_name}]", column_name.humanize, class: "form-label" %>
+        
+        <% if foreign_key && @foreign_key_options[column_name].present? %>
+          <!-- Foreign key dropdown -->
+          <%= form.select "record[#{column_name}]", 
+                      options_for_select(@foreign_key_options[column_name], current_value),
+                      {  }, 
+                      { class: "form-control select2-dropdown", id: field_id, required: required, disabled: disabled } %>
+                      
+        <% elsif field_type == :text %>
+          <!-- Text area for long text fields -->
+          <%= form.text_area "record[#{column_name}]", value: current_value, class: "form-control", id: field_id, rows: 3, required: required, disabled: disabled %>
+          
+        <% elsif field_type == :boolean %>
+          <!-- Boolean field -->
+          <div class="form-check form-switch">
+            <%= form.check_box "record[#{column_name}]", { class: "form-check-input", id: field_id, checked: current_value, disabled: disabled }, "true", "false" %>
+          </div>
+          
+        <% elsif field_type == :datetime %>
+          <!-- Date time picker -->
+          <div class="input-group flatpickr">
+            <%= form.text_field "record[#{column_name}]", value: current_value, class: "form-control datetime-picker", id: field_id, required: required, data: { input: "" }, disabled: disabled %>
+            <button type="button" class="input-group-text" data-toggle><i class="bi bi-calendar-event"></i></button>
+          </div>
+          
+        <% elsif field_type == :date %>
+          <!-- Date picker -->
+          <div class="input-group flatpickr">
+            <%= form.text_field "record[#{column_name}]", value: current_value, class: "form-control date-picker", id: field_id, required: required, data: { input: "" }, disabled: disabled %>
+            <button type="button" class="input-group-text" data-toggle><i class="bi bi-calendar-event"></i></button>
+          </div>
+          
+        <% else %>
+          <!-- Default text input -->
+          <%= form.text_field "record[#{column_name}]", value: current_value, class: "form-control", id: field_id, required: required, disabled: disabled %>
+        <% end %>
+        
+        <% if disabled %>
+          <!-- Add a hidden field to preserve the primary key value -->
+          <%= form.hidden_field "record[#{column_name}]", value: current_value %>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+</div>
+
+<div class="modal-footer">
+  <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+  <button type="submit" form="editRecordForm" class="btn btn-primary" id="updateRecordButton">
+    <i class="bi bi-check-lg me-1"></i>Update Record
+  </button>
+</div>

--- a/app/views/dbviewer/tables/new_record.html.erb
+++ b/app/views/dbviewer/tables/new_record.html.erb
@@ -18,46 +18,15 @@
 <div class="modal-body">
   <%= form_with url: create_record_table_path(@table_name), method: :post, id: "newRecordForm" do |form| %>
     <% @table_columns.each do |column| %>
-      <% 
-        column_name = column[:name]
-        is_primary_key = @metadata[:primary_key] == column_name
-        skip_column = is_primary_key && %w[id].include?(column_name.downcase) 
-        
-        # Skip auto-increment primary keys and timestamps
-        next if skip_column || %w[created_at updated_at].include?(column_name)
-      %>
-      
-      <div class="mb-3">
-        <% 
-          # Handle different field types
-          field_type = determine_field_type(column[:type])
-          foreign_key = @metadata[:foreign_keys].find { |fk| fk[:column] == column_name }
-          field_id = "record_#{column_name}"
-          required = !column[:null]
-        %>
-        
-        <%= form.label "record[#{column_name}]", column_name.humanize, class: "form-label" %>
-        
-        <% if foreign_key && @foreign_key_options[column_name].present? %>
-          <%= form.select "record[#{column_name}]", 
-            options_for_select(@foreign_key_options[column_name]), 
-            { include_blank: column[:null] ? "-- Select --" : false }, 
-            { class: "form-select form-control select2-dropdown" } 
-          %>
-        <% elsif field_type == :check_box %>
-          <div class="form-check">
-            <%= form.check_box "record[#{column_name}]", class: "form-check-input", id: field_id %>
-          </div>
-        <% elsif field_type == :text_area %>
-          <%= form.text_area "record[#{column_name}]", class: "form-control", id: field_id, rows: 3, required: required %>
-        <% else %>
-          <%= form.send(field_type, "record[#{column_name}]", class: "form-control", id: field_id, required: required) %>
-        <% end %>
-        
-        <% if column[:default].present? && column[:default] != "NULL" %>
-          <div class="form-text text-muted">Default: <%= column[:default] %></div>
-        <% end %>
-      </div>
+      <%= render partial: 'dbviewer/tables/record_form_fields', 
+                 locals: { 
+                   form: form, 
+                   column: column, 
+                   metadata: @metadata, 
+                   foreign_key_options: @foreign_key_options, 
+                   record: nil, 
+                   is_edit_mode: false 
+                 } %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/dbviewer/tables/show.html.erb
+++ b/app/views/dbviewer/tables/show.html.erb
@@ -197,7 +197,7 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
         <% if Dbviewer.configuration.enable_record_editing %>
-        <button type="button" class="btn btn-primary" id="recordDetailEditBtn" data-record-id="">
+        <button type="button" class="btn btn-primary" id="recordDetailEditBtn" data-record-id="" data-primary-key="<%= @metadata[:primary_key] || 'id' %>">
           <i class="bi bi-pencil me-1"></i>Edit Record
         </button>
         <% end %>
@@ -449,3 +449,4 @@
 
 <input type="hidden" id="mini_erd_table_path" name="mini_erd_table_path" value="<%= dbviewer.mini_erd_api_table_path(@table_name, format: :json) %>">
 <input type="hidden" id="table_name" name="table_name" value="<%= @table_name %>">
+<input type="hidden" id="table_primary_key" name="table_primary_key" value="<%= @metadata[:primary_key] || 'id' %>">

--- a/app/views/dbviewer/tables/show.html.erb
+++ b/app/views/dbviewer/tables/show.html.erb
@@ -15,6 +15,9 @@
   <%= javascript_include_tag "dbviewer/table", "data-turbo-track": "reload" %>
   <%= javascript_include_tag "dbviewer/record_creation", "data-turbo-track": "reload" %>
   <%= javascript_include_tag "dbviewer/record_deletion", "data-turbo-track": "reload" %>
+  <% if Dbviewer.configuration.enable_record_editing %>
+  <%= javascript_include_tag "dbviewer/record_editing", "data-turbo-track": "reload" %>
+  <% end %>
 <% end %>
 
 <% content_for :sidebar_active do %>active<% end %>
@@ -193,6 +196,11 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <% if Dbviewer.configuration.enable_record_editing %>
+        <button type="button" class="btn btn-primary" id="recordDetailEditBtn" data-record-id="">
+          <i class="bi bi-pencil me-1"></i>Edit Record
+        </button>
+        <% end %>
         <% if Dbviewer.configuration.enable_record_deletion %>
         <button type="button" class="btn btn-danger" id="recordDetailDeleteBtn" data-record-id="">
           <i class="bi bi-trash me-1"></i>Delete Record
@@ -420,6 +428,17 @@
           </button>
         <% end %>
       </div>
+    </div>
+  </div>
+</div>
+<% end %>
+
+<!-- Edit Record Modal -->
+<% if Dbviewer.configuration.enable_record_editing %>
+<div id="editRecordModal" class="modal fade" tabindex="-1" aria-labelledby="editRecordModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <!-- Content will be loaded via AJAX -->
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Dbviewer::Engine.routes.draw do
       get "new_record"
       post "create_record"
       delete "records/:record_id", to: "tables#destroy_record", as: :destroy_record
+      get "records/:record_id/edit", to: "tables#edit_record", as: :edit_record
+      patch "records/:record_id", to: "tables#update_record", as: :update_record
     end
   end
 

--- a/lib/dbviewer/configuration.rb
+++ b/lib/dbviewer/configuration.rb
@@ -120,6 +120,9 @@ module Dbviewer
     # Enable or disable record deletion functionality
     attr_accessor :enable_record_deletion
 
+    # Enable or disable record editing functionality
+    attr_accessor :enable_record_editing
+
     def initialize
       @per_page_options = [ 10, 20, 50, 100 ]
       @default_per_page = 20
@@ -128,6 +131,7 @@ module Dbviewer
       @cache_expiry = 300
       @enable_data_export = false
       @enable_record_deletion = true
+      @enable_record_editing = true
       @query_timeout = 30
       @query_logging_mode = :memory
       @query_log_path = "log/dbviewer.log"

--- a/lib/dbviewer/version.rb
+++ b/lib/dbviewer/version.rb
@@ -1,3 +1,3 @@
 module Dbviewer
-  VERSION = "0.9.4-alpha.2"
+  VERSION = "0.9.4-alpha.3"
 end


### PR DESCRIPTION
This pull request introduces a significant new feature: the ability to edit records directly from the table interface in the DBViewer application. The changes include updates to the front-end, back-end, and configuration to support this functionality. Below is a summary of the most important changes grouped by theme.

### Front-End Enhancements

* Added a new JavaScript file, `record_editing.js`, to handle the record editing workflow, including loading the edit form via AJAX, initializing form elements, and submitting updates.
* Updated the `show.html.erb` view to include the record editing script and an "Edit Record" button in the record detail modal, conditionally displayed based on configuration. [[1]](diffhunk://#diff-b79bb86f4d93eb20abb5894bffce43948c32792a674a91c83bc8240a0eda842dR18-R20) [[2]](diffhunk://#diff-b79bb86f4d93eb20abb5894bffce43948c32792a674a91c83bc8240a0eda842dR199-R203)
* Created a reusable partial `_record_form_fields.html.erb` for rendering form fields, supporting both new record creation and editing.
* Added a new view, `edit_record.html.erb`, to render the edit record modal with dynamic form fields.

### Back-End Updates

* Extended the `TablesController` with new `edit_record` and `update_record` actions for fetching and updating records. These actions include validation and error handling.
* Updated the `validate_table` callback in `TablesController` to include the new actions.

### Configuration and Documentation

* Added a new configuration option, `enable_record_editing`, to toggle the record editing feature. This option is enabled by default and documented in the `README.md` file. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R83-R103) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R124)
* Updated the `CHANGELOG.md` to document the addition of the record editing feature.

### UI Enhancements

* Enhanced the `render_action_cell` helper to include an "Edit Record" button, conditionally rendered based on the `enable_record_editing` configuration. [[1]](diffhunk://#diff-c1e40870ccd339105f3542eaa767f2d604d36057f86750bb7f7ac545ebecf6e8R140-R156) [[2]](diffhunk://#diff-c1e40870ccd339105f3542eaa767f2d604d36057f86750bb7f7ac545ebecf6e8L160-R177)
* Refactored the `new_record.html.erb` view to use the new `_record_form_fields.html.erb` partial for consistency and maintainability.

These changes collectively enable a seamless and user-friendly record editing experience while maintaining configurability and backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced record editing directly from the table interface, including edit buttons in table rows and record detail modals.
  * Edit forms now support enhanced input fields with Select2 and Flatpickr for improved usability.
  * Toast notifications indicate the success or failure of record edits.
  * Record editing can be enabled or disabled via a new configuration option, enabled by default.

* **Documentation**
  * Updated documentation and examples to reflect full CRUD capabilities and new configuration options.

* **Chores**
  * Updated version to 0.9.4-alpha.3 in release notes and versioning files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->